### PR TITLE
Fix rounding function for Intenationalization

### DIFF
--- a/src/main/java/bog/lbpas/view3d/utils/Utils.java
+++ b/src/main/java/bog/lbpas/view3d/utils/Utils.java
@@ -223,13 +223,7 @@ public class Utils {
 
     public static float round(float value, int decimals)
     {
-        String dec = "###.#";
-        for(int i = 1; i < decimals; i++)
-            dec += "#";
-
-        DecimalFormat df = new DecimalFormat(dec);
-
-        return Float.parseFloat(df.format(value));
+        return (float) (Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals));
     }
 
     public static double round(double value, int decimals)


### PR DESCRIPTION
This pull requests fixes the rounding function which uses a locale-based formatting which makes the application not starting in countries like Italy where decimals are indicated by comma instead of dot. This does not use Float.parseFloat and DecimalFormat.